### PR TITLE
Proptypes at the bottom

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Income from './Income'
 import Costs from './Costs'
 import Output from './Output'
+import ErrorCatcher from './../utilities/ErrorCatcher'
 
 class App extends React.Component {
 	state = {
@@ -29,21 +30,23 @@ class App extends React.Component {
 		const amoutCostY = ( ( totalCost * percentageY ) / 100 ).toFixed( 2 )
 
 		return (
-			<section>
-				<h2>Relative Expanses</h2>
-				<Income
-					xSalary={ this.state.xSalary }
-					ySalary={ this.state.ySalary }
-					onChangeIncome={ this.onChangeAmount }
-				/>
-				<hr />
-				<Costs
-					totalCost={ this.state.totalCost }
-					onChangeCosts={ this.onChangeAmount }
-				/>
-				<Output amount={ amoutCostX } />
-				<Output amount={ amoutCostY } />
-			</section>
+			<ErrorCatcher>
+				<section>
+					<h2>Relative Expanses</h2>
+					<Income
+						xSalary={ this.state.xSalary }
+						ySalary={ this.state.ySalary }
+						onChangeIncome={ this.onChangeAmount }
+					/>
+					<hr />
+					<Costs
+						totalCost={ this.state.totalCost }
+						onChangeCosts={ this.onChangeAmount }
+					/>
+					<Output amount={ +amoutCostX } />
+					<Output amount={ +amoutCostY } />
+				</section>
+			</ErrorCatcher>
 		)
 	}
 }

--- a/src/components/Costs.jsx
+++ b/src/components/Costs.jsx
@@ -2,11 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 class Costs extends React.Component {
-	static propTypes = {
-		onChangeCosts: PropTypes.func.isRequired,
-		totalCost: PropTypes.number.isRequired,
-	}
-
 	setCosts = ( event ) => {
 		this.props.onChangeCosts( event.target.value, 'totalCost' )
 	}
@@ -16,14 +11,17 @@ class Costs extends React.Component {
 			<form>
 				<input
 					onChange={ this.setCosts }
-					defaultValue={
-						this.props.totalCost
-					}
+					defaultValue={ this.props.totalCost }
 					type="number"
 					placeholder="..Total cost.."
 				/>
 			</form>
 		)
+	}
+
+	static propTypes = {
+		onChangeCosts: PropTypes.func.isRequired,
+		totalCost: PropTypes.number.isRequired,
 	}
 }
 

--- a/src/components/Costs.jsx
+++ b/src/components/Costs.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 class Costs extends React.Component {
+	static propTypes = {
+		onChangeCosts: PropTypes.func.isRequired,
+		totalCost: PropTypes.number.isRequired,
+	}
+
 	setCosts = ( event ) => {
-		// eslint-disable-next-line react/prop-types
 		this.props.onChangeCosts( event.target.value, 'totalCost' )
 	}
 
@@ -12,7 +17,6 @@ class Costs extends React.Component {
 				<input
 					onChange={ this.setCosts }
 					defaultValue={
-						// eslint-disable-next-line react/prop-types
 						this.props.totalCost
 					}
 					type="number"

--- a/src/components/Income.jsx
+++ b/src/components/Income.jsx
@@ -1,8 +1,14 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 class Income extends React.Component {
+	static propTypes = {
+		onChangeIncome: PropTypes.func.isRequired,
+		xSalary: PropTypes.number.isRequired,
+		ySalary: PropTypes.number.isRequired,
+	}
+
 	setIncome = ( event, field ) => {
-		// eslint-disable-next-line react/prop-types
 		this.props.onChangeIncome( event.target.value, field )
 	}
 
@@ -12,7 +18,6 @@ class Income extends React.Component {
 				<input
 					onChange={ ( e ) => this.setIncome( e, 'xSalary' ) }
 					defaultValue={
-						// eslint-disable-next-line react/prop-types
 						this.props.xSalary
 					}
 					type="number"
@@ -21,7 +26,6 @@ class Income extends React.Component {
 				<input
 					onChange={ ( e ) => this.setIncome( e, 'ySalary' ) }
 					defaultValue={
-						// eslint-disable-next-line react/prop-types
 						this.props.ySalary
 					}
 					type="number"

--- a/src/components/Income.jsx
+++ b/src/components/Income.jsx
@@ -2,12 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 class Income extends React.Component {
-	static propTypes = {
-		onChangeIncome: PropTypes.func.isRequired,
-		xSalary: PropTypes.number.isRequired,
-		ySalary: PropTypes.number.isRequired,
-	}
-
 	setIncome = ( event, field ) => {
 		this.props.onChangeIncome( event.target.value, field )
 	}
@@ -17,22 +11,24 @@ class Income extends React.Component {
 			<form>
 				<input
 					onChange={ ( e ) => this.setIncome( e, 'xSalary' ) }
-					defaultValue={
-						this.props.xSalary
-					}
+					defaultValue={ this.props.xSalary }
 					type="number"
 					placeholder="..X net salary.."
 				/>
 				<input
 					onChange={ ( e ) => this.setIncome( e, 'ySalary' ) }
-					defaultValue={
-						this.props.ySalary
-					}
+					defaultValue={ this.props.ySalary }
 					type="number"
 					placeholder="..Y net salary.."
 				/>
 			</form>
 		)
+	}
+
+	static propTypes = {
+		onChangeIncome: PropTypes.func.isRequired,
+		xSalary: PropTypes.number.isRequired,
+		ySalary: PropTypes.number.isRequired,
 	}
 }
 

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
+import PropTypes  from 'prop-types'
+
+Output.propTypes = {
+	amount: PropTypes.number.isRequired,
+}
 
 const Output = ( props ) => {
-	// eslint-disable-next-line react/prop-types
 	const amount = props.amount && !isNaN( props.amount ) ? props.amount : 0
 	return (
 		<span>

--- a/src/components/Output.jsx
+++ b/src/components/Output.jsx
@@ -1,9 +1,5 @@
 import React from 'react'
-import PropTypes  from 'prop-types'
-
-Output.propTypes = {
-	amount: PropTypes.number.isRequired,
-}
+import PropTypes from 'prop-types'
 
 const Output = ( props ) => {
 	const amount = props.amount && !isNaN( props.amount ) ? props.amount : 0
@@ -12,6 +8,10 @@ const Output = ( props ) => {
 			<output>{ amount }</output>
 		</span>
 	)
+}
+
+Output.propTypes = {
+	amount: PropTypes.number.isRequired,
 }
 
 export default Output

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,15 @@
+/* eslint react/jsx-filename-extension: 0 */
 import React from 'react'
 import { render } from 'react-dom'
 
+import './styles/style.css'
+import ErrorCatcher from './utilities/ErrorCatcher'
 import App from './components/App'
 
-import './styles/style.css'
-// eslint-disable-next-line react/jsx-filename-extension
-render( <App />, document.getElementById( 'root' ) )
+const app = (
+	<ErrorCatcher>
+		<App />
+	</ErrorCatcher>
+)
+
+render( app, document.getElementById( 'root' ) )

--- a/src/utilities/ErrorCatcher.jsx
+++ b/src/utilities/ErrorCatcher.jsx
@@ -10,10 +10,6 @@ export default class ErrorCatcher extends React.Component {
 		}
 	}
 
-	static propTypes = {
-		children: PropTypes.element,
-	}
-
 	componentDidCatch( error, info ) {
 		this.setState( ( state ) => ( {
 			errorFound: !state.errorFound,
@@ -32,5 +28,9 @@ export default class ErrorCatcher extends React.Component {
 		) : (
 			this.props.children
 		)
+	}
+
+	static propTypes = {
+		children: PropTypes.element,
 	}
 }

--- a/src/utilities/ErrorCatcher.jsx
+++ b/src/utilities/ErrorCatcher.jsx
@@ -1,0 +1,36 @@
+/* eslint  no-console: off */
+import React from 'react'
+import { PropTypes } from 'prop-types'
+
+export default class ErrorCatcher extends React.Component {
+	constructor( props ) {
+		super( props )
+		this.state = {
+			errorFound: false,
+		}
+	}
+
+	static propTypes = {
+		children: PropTypes.element,
+	}
+
+	componentDidCatch( error, info ) {
+		this.setState( ( state ) => ( {
+			errorFound: !state.errorFound,
+		} ) )
+		console.log( 'error: ', error )
+		console.log( 'info: ', info )
+	}
+
+	render() {
+		return this.state.errorFound ? (
+			<p>
+				Error caught!
+				{ }
+				The calculator becomes useless with just a single error.
+			</p>
+		) : (
+			this.props.children
+		)
+	}
+}


### PR DESCRIPTION
Since Facebook guidelines on React  uses proptypes at the bototm of a component (and it's not normal for the JS compilier since you are doing things on an unexisting object) I suggest to use the new static properties syntax to declare proptypes but then move them at the bottom to follow the guideline and current trend.